### PR TITLE
Add additional fields to the OptionContract struct and update tests

### DIFF
--- a/src/model/market_data/option_chain.rs
+++ b/src/model/market_data/option_chain.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use serde_with::{serde_as, TimestampMilliSeconds};
 use std::collections::HashMap;
 
+use super::quote_response::option::ExerciseType;
 use super::quote_response::option::ExpirationType;
 use super::quote_response::option::SettlementType;
 
@@ -75,12 +76,15 @@ pub struct OptionContract {
     pub mark_price: Option<f64>,
     pub bid_size: i64,
     pub ask_size: i64,
+    pub bid_ask_size: String,
     pub last_size: i64,
     pub high_price: f64,
     pub low_price: f64,
     pub open_price: f64,
     pub close_price: f64,
     pub total_volume: u64,
+    pub high52_week: f64,
+    pub low52_week: f64,
     #[serde_as(as = "Option<TimestampMilliSeconds<i64>>")]
     pub trade_date: Option<chrono::DateTime<chrono::Utc>>,
     #[serde_as(as = "TimestampMilliSeconds<i64>")]
@@ -118,6 +122,7 @@ pub struct OptionContract {
     pub is_penny_pilot: Option<bool>,
     pub intrinsic_value: f64,
     pub option_root: String,
+    pub exercise_type: ExerciseType,
 
     // not in schema
     pub bid: Option<f64>,

--- a/tests/model/MarketData/OptionChain.json
+++ b/tests/model/MarketData/OptionChain.json
@@ -93,7 +93,12 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
+
                 }
             ],
             "additionalProp2": [
@@ -153,7 +158,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ],
             "additionalProp3": [
@@ -213,7 +222,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ]
         },
@@ -275,7 +288,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ],
             "additionalProp2": [
@@ -335,7 +352,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ],
             "additionalProp3": [
@@ -395,7 +416,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ]
         },
@@ -457,7 +482,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ],
             "additionalProp2": [
@@ -517,7 +546,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ],
             "additionalProp3": [
@@ -577,7 +610,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ]
         }
@@ -641,7 +678,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ],
             "additionalProp2": [
@@ -701,7 +742,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ],
             "additionalProp3": [
@@ -761,7 +806,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ]
         },
@@ -823,7 +872,12 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
+ 
                 }
             ],
             "additionalProp2": [
@@ -883,7 +937,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ],
             "additionalProp3": [
@@ -943,7 +1001,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ]
         },
@@ -1005,7 +1067,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ],
             "additionalProp2": [
@@ -1065,7 +1131,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ],
             "additionalProp3": [
@@ -1125,7 +1195,11 @@
                     "markPercentChange": 0,
                     "isPennyPilot": true,
                     "intrinsicValue": 0,
-                    "optionRoot": "string"
+                    "optionRoot": "string",
+                    "high52Week": 0,
+                    "low52Week": 0,
+                    "bidAskSize": "string",
+                    "exerciseType": "A"
                 }
             ]
         }


### PR DESCRIPTION
Noticed some fields were missing from the deserialization from JSON into the struct. This adds those additional fields to the OptionContract struct and update tests (bidAskSize, high52Week, low52Week, exerciseType).

Fields are already present in `tests/model/MarketData/OptionChain_real.json`
Ran `cargo test` and `cargo +nightly fmt`. 