### PR TITLE
Start callback server using redirect_url for auto auth mode

### DIFF
--- a/src/token/local_server.rs
+++ b/src/token/local_server.rs
@@ -6,10 +6,16 @@ use axum::{
 };
 use axum_server::tls_rustls::RustlsConfig;
 use oauth2::CsrfToken;
+use reqwest::redirect;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use url::Url;
 
-pub(super) async fn local_server(csrf: CsrfToken, certs_dir: PathBuf) -> String {
+pub(super) async fn local_server(
+    csrf: CsrfToken,
+    certs_dir: PathBuf,
+    redirect_url: &String,
+) -> String {
     let (tx, rx) = async_channel::unbounded();
 
     let app_state = AppState { csrf, tx };
@@ -19,7 +25,8 @@ pub(super) async fn local_server(csrf: CsrfToken, certs_dir: PathBuf) -> String 
         .await
         .expect("certs setting ok");
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
+    // Derive SocketAddr from redirect_url
+    let addr = parse_socket_addr(redirect_url).unwrap();
 
     tokio::spawn(axum_server::bind_rustls(addr, config).serve(app(app_state).into_make_service()));
 
@@ -57,6 +64,26 @@ async fn get_code(
     content
 }
 
+fn parse_socket_addr(redirect_url: &String) -> Result<SocketAddr, String> {
+    let url = match Url::parse(redirect_url) {
+        Ok(url) => url,
+        Err(err) => return Err(format!("Failed to parse URL: {}", err)),
+    };
+
+    let hostname = match url.host_str() {
+        Some(hostname) => hostname,
+        None => return Err("No hostname found in URL".to_string()),
+    };
+
+    let port = url.port().unwrap_or(443); // default to HTTPS port if not specified
+
+    let addr = format!("{}:{}", hostname, port);
+    match addr.parse::<SocketAddr>() {
+        Ok(addr) => Ok(addr),
+        Err(err) => Err(format!("Failed to parse socket address: {}", err)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,6 +96,47 @@ mod tests {
 
     fn config(csrf: CsrfToken, tx: async_channel::Sender<String>) -> AppState {
         AppState { csrf, tx }
+    }
+
+    #[test]
+    fn test_parse_socket_addr() {
+        // Valid URL with specified port
+        let expected_addr = SocketAddr::from(([127, 0, 0, 1], 8080));
+        let addr = parse_socket_addr(&"https://127.0.0.1:8080".to_string()).unwrap();
+        assert_eq!(addr, expected_addr);
+
+        // Valid URL with default HTTPS port
+        let expected_addr = SocketAddr::from(([127, 0, 0, 1], 443));
+        let addr = parse_socket_addr(&"https://127.0.0.1".to_string()).unwrap();
+        assert_eq!(addr, expected_addr);
+
+        // Invalid URL
+        let err = parse_socket_addr(&"invalid_url".to_string()).unwrap_err();
+        assert_eq!(err, "Failed to parse URL: relative URL without a base");
+
+        // URL without hostname
+        let err = parse_socket_addr(&"https:///path".to_string()).unwrap_err();
+        assert_eq!(
+            err,
+            "Failed to parse socket address: invalid socket address syntax"
+        );
+
+        // URL with non-standard port
+        let expected_addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+        let addr = parse_socket_addr(&"https://127.0.0.1:3000".to_string()).unwrap();
+        assert_eq!(addr, expected_addr);
+
+        // URL with IP address and port
+        let expected_addr = SocketAddr::from(([192, 168, 1, 1], 8080));
+        let addr = parse_socket_addr(&"https://192.168.1.1:8080".to_string()).unwrap();
+        assert_eq!(addr, expected_addr);
+
+        // URL with hostname and port; for now, this is not supported
+        let addr = parse_socket_addr(&"http://example.com:80".to_string()).unwrap_err();
+        assert_eq!(
+            addr,
+            "Failed to parse socket address: invalid socket address syntax"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
This addresses issue #4.

`cargo test` passes, but I had some trouble with `cargo test -- --ignored --nocapture` with some instantiation of the server at port 443 for my Schwab Application. I requested a change to use port 8081, and it is pending approval. At least per the unit tests, the behavior appears as expected. 