### PR TITLE
Return order id from (post|put)_account_order_request

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -822,26 +822,15 @@ mod tests {
             .post_account_order(account_number().await, order_post.clone())
             .await
             .unwrap();
-        req.send().await.unwrap();
+        let order_id = req.send().await.unwrap();
 
         // post check
         let req = api
-            .get_account_orders(
-                account_number().await,
-                chrono::Local::now()
-                    .checked_sub_days(chrono::Days::new(1))
-                    .unwrap()
-                    .to_utc(),
-                chrono::Local::now()
-                    .checked_add_days(chrono::Days::new(1))
-                    .unwrap()
-                    .to_utc(),
-            )
+            .get_account_order(account_number().await, order_id)
             .await
             .unwrap();
-        let orders = req.send().await.unwrap();
-        dbg!(&orders);
-        let order_post_check = orders[0].clone();
+        let order_post_check = req.send().await.unwrap();
+        dbg!(&order_post_check);
         assert_eq!(
             order_post_check.session,
             model::trader::order::Session::Normal
@@ -879,10 +868,9 @@ mod tests {
             .put_account_order(account_number().await, order_id, order_put.clone())
             .await
             .unwrap();
-        req.send().await.unwrap();
+        let order_id = req.send().await.unwrap();
 
         // put check
-        let order_id = order_id + 1;
         let req = api
             .get_account_order(account_number().await, order_id)
             .await

--- a/src/api.rs
+++ b/src/api.rs
@@ -822,7 +822,7 @@ mod tests {
             .post_account_order(account_number().await, order_post.clone())
             .await
             .unwrap();
-        let order_id = req.send().await.unwrap();
+        let order_id = req.send().await.unwrap().unwrap();
 
         // post check
         let req = api
@@ -868,7 +868,7 @@ mod tests {
             .put_account_order(account_number().await, order_id, order_put.clone())
             .await
             .unwrap();
-        let order_id = req.send().await.unwrap();
+        let order_id = req.send().await.unwrap().unwrap();
 
         // put check
         let req = api

--- a/src/api/trader.rs
+++ b/src/api/trader.rs
@@ -380,7 +380,7 @@ fn parse_order_id_from_headers(headers: &HeaderMap) -> Result<i64, Error> {
         .to_str()
         .map_err(|e| Error::OrderIdParseError(e.to_string()))?
         .split('/')
-        .last()
+        .next_back()
         .ok_or_else(|| Error::OrderIdParseError("No slashes found in location header.".to_string()))?
         .parse::<i64>()
         .map_err(|e| Error::OrderIdParseError(e.to_string()))

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,4 +20,6 @@ pub enum Error {
     Json(#[from] serde_json::Error),
     #[error("ChannelMessenger error: {0}")]
     ChannelMessenger(String),
+    #[error("Order Id parse error: {0}")]
+    OrderIdParseError(String),
 }


### PR DESCRIPTION
Status: Ready for review, not ready for merge. Needs tests and feedback.

Hey @z-Wind,

I wanted to open a discussion about returning the order id values from the PUT and POST calls for orders. I find this really useful for managing the orders, otherwise querying the order book and trying to match things up can get very painful.

1. I added a new error type to get this to work, but I doubt `OrderIdParseError` is actually something you're interested in having in the error enum. Thoughts on adding a more general error type for things like this?
2. I'm a little torn on whether this even _should_ error, given that if the code got this far the order was actually placed.
3. Any opinion on where a helper method like this should live inside this code base?
4. Open to general comments on my Rust / criticism as to how un-idiomatic this might be. I'm very new to Rust.

I'm happy to write some tests and get this tuned up conditional on your feedback and you actually being interested in merging the change.

Thanks for the crate by the way!