### PR TITLE
Fix: Parse Error for BuyWrite

### DIFF
--- a/src/model/trader/accounts.rs
+++ b/src/model/trader/accounts.rs
@@ -255,7 +255,7 @@ pub struct AccountOption {
     /// xml: `OrderedMap` { "name": "optionDeliverables", "wrapped": true }
     pub option_deliverables: Vec<AccountAPIOptionDeliverable>,
     pub put_call: AccountOptionPullCall,
-    pub option_multiplier: i64,
+    pub option_multiplier: Option<i64>,
     #[serde(rename = "type")]
     pub type_field: AccountOptionType,
     pub underlying_symbol: String,
@@ -282,13 +282,13 @@ pub struct AccountCollectiveInvestment {
     pub accounts_base_instrument: AccountsBaseInstrument,
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountAPIOptionDeliverable {
-    pub symbol: i64,
+    pub symbol: String,
     pub deliverable_units: f64,
-    pub api_currency_type: APICurrencyType,
-    pub asset_type: AssetType,
+    pub api_currency_type: Option<APICurrencyType>,
+    pub asset_type: Option<AssetType>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -296,7 +296,7 @@ pub struct AccountAPIOptionDeliverable {
 pub struct AccountsBaseInstrument {
     pub cusip: String,
     pub symbol: String,
-    pub description: String,
+    pub description: Option<String>,
     pub instrument_id: i64,
     pub net_change: Option<f64>,
 }

--- a/src/model/trader/order.rs
+++ b/src/model/trader/order.rs
@@ -469,6 +469,16 @@ mod tests {
         let val = serde_json::from_str::<Order>(json);
         println!("{val:?}");
         assert!(val.is_ok());
+
+        // Second real order
+        let json = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/model/Trader/Order_real2.json"
+        ));
+
+        let val = serde_json::from_str::<Order>(json);
+        println!("{val:?}");
+        assert!(val.is_ok());
     }
 
     #[test]

--- a/src/model/trader/order.rs
+++ b/src/model/trader/order.rs
@@ -469,8 +469,10 @@ mod tests {
         let val = serde_json::from_str::<Order>(json);
         println!("{val:?}");
         assert!(val.is_ok());
+    }
 
-        // Second real order
+    #[test]
+    fn test_de_order_real2() {
         let json = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/tests/model/Trader/Order_real2.json"

--- a/tests/model/Trader/Order_real2.json
+++ b/tests/model/Trader/Order_real2.json
@@ -1,0 +1,59 @@
+{
+  "session": "NORMAL",
+  "duration": "DAY",
+  "orderType": "NET_DEBIT",
+  "complexOrderStrategyType": "COVERED",
+  "quantity": 1.0,
+  "filledQuantity": 0.0,
+  "remainingQuantity": 1.0,
+  "requestedDestination": "AUTO",
+  "destinationLinkName": "AutoRoute",
+  "price": 10.0,
+  "orderLegCollection": [
+    {
+      "orderLegType": "EQUITY",
+      "legId": 1,
+      "instrument": {
+        "assetType": "EQUITY",
+        "cusip": "345370860",
+        "symbol": "F",
+        "instrumentId": 2947182
+      },
+      "instruction": "BUY",
+      "positionEffect": "OPENING",
+      "quantity": 100.0
+    },
+    {
+      "orderLegType": "OPTION",
+      "legId": 2,
+      "instrument": {
+        "assetType": "OPTION",
+        "cusip": "0F....CK60014000",
+        "symbol": "F     260320C00014000",
+        "description": "FORD MTR CO DEL 03/20/2026 $14 Call",
+        "instrumentId": 241079162,
+        "type": "VANILLA",
+        "putCall": "CALL",
+        "underlyingSymbol": "F",
+        "optionDeliverables": [
+          {
+            "symbol": "F",
+            "deliverableUnits": 100.0
+          }
+        ]
+      },
+      "instruction": "SELL_TO_OPEN",
+      "positionEffect": "OPENING",
+      "quantity": 1.0
+    }
+  ],
+  "orderStrategyType": "SINGLE",
+  "orderId": 1234567890123,
+  "cancelable": true,
+  "editable": true,
+  "status": "PENDING_ACTIVATION",
+  "enteredTime": "2025-10-31T20:09:15+0000",
+  "tag": "TA_FAKE",
+  "accountNumber": 12345678
+}
+


### PR DESCRIPTION
# Summary
I ran into an issue deserializing the response from Schwab for a BuyWrite (COVERED) order. Some of the field types were not marked Option, and one was an i64 but coming back from the API as String. I added a test with real data (though I altered the order id and account id for privacy).

## Testing
I've added a new test case that follows the existing pattern testing against real API results.

## Checklist

- [x] Added new tests exhibiting erroneous behavior.
- [x] Implemented fix causing test to pass.
- [x] `cargo check` passes all tests.
- [x] `cargo clip --all-targets` comes back clean.

I'm happy to make any edits necessary to get this merged. 

Unrelated, but worth mentioning: I'll probably spend some time next week writing some docs for how to construct various order types. Also I've got automatic generation of the SSL certs working on this end, if you're interested in a patch for that.